### PR TITLE
v3.3.1 - Hotifx - Speed up custom panel page

### DIFF
--- a/ExonCov/forms.py
+++ b/ExonCov/forms.py
@@ -6,6 +6,7 @@ from flask_security.forms import RegisterForm
 from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField, QuerySelectField
 from wtforms.fields import SelectField, TextAreaField, StringField, BooleanField, FloatField
 from wtforms import validators
+import datetime
 
 from .models import Sample, SampleSet, Gene, GeneAlias, PanelVersion, Panel
 
@@ -13,7 +14,8 @@ from .models import Sample, SampleSet, Gene, GeneAlias, PanelVersion, Panel
 # Query factories
 def all_samples():
     """Query factory for all samples."""
-    return Sample.query.all()
+    #return Sample.query.all()
+    return Sample.query.filter(Sample.name.like('%C%')).filter(Sample.import_date >= datetime.date.today() - datetime.timedelta(days=365*2)).all()
 
 
 def active_sample_sets():

--- a/ExonCov/templates/custom_panel_new.html
+++ b/ExonCov/templates/custom_panel_new.html
@@ -4,6 +4,11 @@
 {% block header %}Custom gene panel{% endblock %}
 
 {% block body %}
+<div class="alert alert-warning" role="alert">
+    Because of performance issues we have temporay disabled custom panel creation for 'parent samples' and samples older than 2 years.<br>
+    Please contact <b>bioinformatica-genetica@umcutrecht.nl</b> if you would like to create a custom panel containing a 'parent sample' or sample older than 2 years.
+</div>
+
 <div class="well">
     <form method="POST" action="{{ url_for('custom_panel_new') }}" class="form-horizontal">
         {{ form.csrf_token }}


### PR DESCRIPTION
Speed up custom panel page by showing less samples in custom panel form:
- Remove samples uploaded more than two years ago.
- Only show samples with 'C' in sample name (children).


This is an temporary fix and will be replaced with a permanent solution.