### PR TITLE
Hotifx/v3.4.1 - Fix sql timeouts when uploading samples with high coverage.

### DIFF
--- a/ExonCov/cli.py
+++ b/ExonCov/cli.py
@@ -178,6 +178,9 @@ class ImportBam(Command):
         sample.exon_measurement_file = '{0}_{1}.txt'.format(sample.id, sample.exon_measurement_file)
         db.session.add(sample)
         db.session.commit()
+        # Store sample_id and close session before starting Sambamba
+        sample_id = sample.id
+        db.session.close()
 
         # Create temp_dir
         if not temp_path:
@@ -264,6 +267,7 @@ class ImportBam(Command):
         os.system('rsync {0}* {1}'.format(exon_measurement_file_path_gz, app.config['EXON_MEASUREMENTS_RSYNC_PATH']))
 
         # Change exon_measurement_file to path on server.
+        sample = Sample.query.get(sample_id)
         sample.exon_measurement_file = '{0}/{1}.gz'.format(
             app.config['EXON_MEASUREMENTS_RSYNC_PATH'].split(':')[-1],
             sample.exon_measurement_file

--- a/config.py
+++ b/config.py
@@ -5,6 +5,13 @@ SQLALCHEMY_DATABASE_URI = 'mysql://exoncov3:exoncov3@localhost/exoncov3'
 SQLALCHEMY_ECHO = False
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+# SQLAlchemy CLI settings, enable when using CLI
+# SQLALCHEMY_ENGINE_OPTIONS = {
+#    'pool_size' : 1,
+#    'pool_recycle': 120,
+#    'pool_pre_ping': True
+# }
+
 # FlaskForm
 SECRET_KEY = 'change_this'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.4.1
 Flask-Migrate==2.5.2
 Flask-Script==2.0.6
 Flask-Security==3.0.0
-Flask-SQLAlchemy==2.3.2
+Flask-SQLAlchemy==2.4.4
 Flask-WTF==0.14.2
 MySQL-python==1.2.5
 SQLAlchemy==1.3.5


### PR DESCRIPTION
Update to fix SQL timeouts when uploading samples with high coverage.

- Store sample id and close current SQL session.
- Set pool size to 1 to enforce 1 connection per session. (which is closed by closing the session).
- Update Flask-SQLAlchemy to 2.4.4 to enable configuration options.