### PR TITLE
fixed typo

### DIFF
--- a/ExonCov/views.py
+++ b/ExonCov/views.py
@@ -998,7 +998,7 @@ def sample_set_gene(sample_set_id, gene_id):
     return render_template(
         'sample_set_gene.html',
         form=measurement_type_form,
-        ene=gene,
+        gene=gene,
         sample_set=sample_set,
         measurement_type=measurement_type,
         transcript_measurements=transcript_measurements


### PR DESCRIPTION
Hotfix

Currently users cannot generate gene views because a single letter is missing in the render function, crashing the script.